### PR TITLE
Implement load_mnist function to load MNIST dataset from CSV

### DIFF
--- a/src/fun_utils.py
+++ b/src/fun_utils.py
@@ -32,3 +32,22 @@ def split_data(x, y, tr_fraction=0.5):
 
     """
     pass
+
+def load_mnist(csv_filename: str):
+    """
+    Load the MNIST dataset from a csv file
+
+    Parameters
+    ----------
+    csv_filename : string
+        Filename to be loaded.
+
+    Returns
+    -------
+    X : ndarray
+        the data matrix.
+
+    y : ndarray
+        the labels of each sample.
+    """
+    return load_data(csv_filename)


### PR DESCRIPTION
This pull request adds a new utility function to make loading the MNIST dataset from a CSV file more convenient.

Data loading utilities:

* Added a `load_mnist` function to `src/fun_utils.py` that loads the MNIST dataset from a CSV file by calling the existing `load_data` function. This provides a clearer interface for users working specifically with MNIST data.